### PR TITLE
fix: arguments are being skipped if empty

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,4 +23,4 @@ fi
 mkdir -p ~/.ssh
 cp /root/.ssh/* ~/.ssh/ 2> /dev/null || true
 
-sh -c "/git-mirror.sh $*"
+sh -c "/git-mirror.sh \"$*\""


### PR DESCRIPTION
when using $* the empty parameters were skipped due to missing quotes
ref https://wiki.bash-hackers.org/scripting/posparams#all_positional_parameters